### PR TITLE
Add TAKEOUT_INIT_DELAY handle

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -28,11 +28,11 @@ pub async fn analyze(config: Analyze, client: &Client) -> Result<(), InvocationE
             Err(err) => {
                 match err {
                     InvocationError::Rpc(RpcError {
-                        code: _code @ 420,
+                        code: code @ 420,
                         value,
                         ..
                     }) => {
-                        debug!(?value, "Sorry, for security reasons, you will be able to begin downloading your data in %d seconds. We have notified all your devices about the export request to make sure it's authorized and to give you time to react if it's not.");
+                        error!(?value, code, "Sorry, for security reasons, you will be able to begin downloading your data in %d seconds. We have notified all your devices about the export request to make sure it's authorized and to give you time to react if it's not.");
                     }
                     _ => {
                         error!(%err, "Error while get group messages");

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,3 +1,5 @@
+use std::process;
+
 use super::models::{Analyze, Delete, Join};
 use crate::client::{
     analyze::{self, Chat},
@@ -21,7 +23,26 @@ pub async fn analyze(config: Analyze, client: &Client) -> Result<(), InvocationE
     if config.left {
         println!("Analyze the chats that you're left. It may take a few minutes.");
 
-        let takeout_id = analyze::init_takeout_session(client).await?;
+        let takeout_id = match analyze::init_takeout_session(client).await {
+            Ok(takeout_id) => takeout_id,
+            Err(err) => {
+                match err {
+                    InvocationError::Rpc(RpcError {
+                        code: _code @ 420,
+                        value,
+                        ..
+                    }) => {
+                        debug!(?value, "Sorry, for security reasons, you will be able to begin downloading your data in %d seconds. We have notified all your devices about the export request to make sure it's authorized and to give you time to react if it's not.");
+                    }
+                    _ => {
+                        error!(%err, "Error while get group messages");
+                    }
+                };
+
+                process::exit(1);
+            }
+        };
+
         let success = match analyze::get_left_chats(client, takeout_id).await {
             Ok(left_chats) => {
                 chats = chats.into_iter().chain(left_chats).collect();


### PR DESCRIPTION
When you run command 
```
tg_old_chats_manager analyze --left
```
you can get Telegram error [TAKEOUT_INIT_DELAY](https://core.telegram.org/method/account.initTakeoutSession#possible-errors) without description why this error occurred. My pull request is aimed at allowing the user to conveniently see the cause of the error, rather than searching for it manually using the error code.